### PR TITLE
Bump grpc-js to 1.1.3-exodus.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
   },
   "dependencies": {
     "@exodus/google-protobuf": "^3.13.0-exodus.1",
-    "@exodus/grpc-js": "^1.1.3-exodus.4",
+    "@exodus/grpc-js": "^1.1.3-exodus.5",
     "@exodus/improbable-eng-grpc-web-fork": "^0.13.0-exodus.0",
     "@stablelib/hex": "^1.0.0",
     "@stablelib/utf8": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -124,9 +124,9 @@
     "node": ">=10.0.0"
   },
   "dependencies": {
-    "@exodus/google-protobuf": "3.13.0-exodus.1",
-    "@exodus/grpc-js": "1.1.3-exodus.4",
-    "@exodus/improbable-eng-grpc-web-fork": "0.13.0-exodus.0",
+    "@exodus/google-protobuf": "^3.13.0-exodus.1",
+    "@exodus/grpc-js": "^1.1.3-exodus.4",
+    "@exodus/improbable-eng-grpc-web-fork": "^0.13.0-exodus.0",
     "@stablelib/hex": "^1.0.0",
     "@stablelib/utf8": "^1.0.0",
     "bignumber.js": "^8.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -333,7 +333,7 @@
   resolved "https://registry.yarnpkg.com/@exodus/google-protobuf/-/google-protobuf-3.13.0-exodus.1.tgz#724e98c54242ca45a555c7ca24a1b26cbf7073c6"
   integrity sha512-wIjn7psISuijdtjqQti5BYdH4SKqAAKb5v2494OjuUmh2oWrMRgcrCjs/uUf3levwn1Ou1seifJTP31lO9jvZg==
 
-"@exodus/grpc-js@^1.1.3-exodus.4":
+"@exodus/grpc-js@^1.1.3-exodus.5":
   version "1.1.3-exodus.5"
   resolved "https://registry.yarnpkg.com/@exodus/grpc-js/-/grpc-js-1.1.3-exodus.5.tgz#259bf7f6ca7cc890c8cf6c189912cee9736a53af"
   integrity sha512-X5MsnmidY5SfqXZPd5X/mBAJbIi/6zXuEFCX9zgo8fl5N4Jkbl6+y1wsq4gdgPD2HmnyVt1JjTY7JqnZS17B2w==

--- a/yarn.lock
+++ b/yarn.lock
@@ -328,19 +328,19 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@exodus/google-protobuf@3.13.0-exodus.1":
+"@exodus/google-protobuf@^3.13.0-exodus.1":
   version "3.13.0-exodus.1"
   resolved "https://registry.yarnpkg.com/@exodus/google-protobuf/-/google-protobuf-3.13.0-exodus.1.tgz#724e98c54242ca45a555c7ca24a1b26cbf7073c6"
   integrity sha512-wIjn7psISuijdtjqQti5BYdH4SKqAAKb5v2494OjuUmh2oWrMRgcrCjs/uUf3levwn1Ou1seifJTP31lO9jvZg==
 
-"@exodus/grpc-js@1.1.3-exodus.4":
-  version "1.1.3-exodus.4"
-  resolved "https://registry.yarnpkg.com/@exodus/grpc-js/-/grpc-js-1.1.3-exodus.4.tgz#31a817b18cb9304e08dc7e8ba6ddbb4a209c8b1d"
-  integrity sha512-CilBtl2G9mjtU45SY2hHpCU2/nLRyJqB2mrPdxF+B4qVe1fZAM5M52NFq8cR4V21WiROxUpphj/FHlnNE3cgJg==
+"@exodus/grpc-js@^1.1.3-exodus.4":
+  version "1.1.3-exodus.5"
+  resolved "https://registry.yarnpkg.com/@exodus/grpc-js/-/grpc-js-1.1.3-exodus.5.tgz#259bf7f6ca7cc890c8cf6c189912cee9736a53af"
+  integrity sha512-X5MsnmidY5SfqXZPd5X/mBAJbIi/6zXuEFCX9zgo8fl5N4Jkbl6+y1wsq4gdgPD2HmnyVt1JjTY7JqnZS17B2w==
   dependencies:
     semver "^5.5.1"
 
-"@exodus/improbable-eng-grpc-web-fork@0.13.0-exodus.0":
+"@exodus/improbable-eng-grpc-web-fork@^0.13.0-exodus.0":
   version "0.13.0-exodus.0"
   resolved "https://registry.yarnpkg.com/@exodus/improbable-eng-grpc-web-fork/-/improbable-eng-grpc-web-fork-0.13.0-exodus.0.tgz#40555a6836c2bd632cd179ca29ed9f2611f8e67d"
   integrity sha512-SqZqfxrw4tJzgPrm3zOpPyVDCxOCiwBFr6tNe3BvPHGgrfbiW8hrPJ3clAwzDhs+Qqm+YWbQUry200O1Lf+ApQ==


### PR DESCRIPTION
Bumps `@exodus/grpc-js` to bring in changes from https://github.com/ExodusMovement/grpc-js/pull/2

Also unpins versions for `@exodus` deps, as [requested by @ChALkeR in slack](https://exodusio.slack.com/archives/C0SBA8WE8/p1604616958139600?thread_ts=1604614427.135500&cid=C0SBA8WE8)