### PR TITLE
fix: serialization

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,8 +23,7 @@
         ".": {
             "import": "./src/browser.js",
             "require": "./lib/browser.cjs"
-        },
-        "./lib/transaction/SignatureMap.cjs": "./lib/transaction/SignatureMap.cjs"
+        }
     },
     "license": "Apache-2.0",
     "author": "Launchbadge <contact@launchbadge.com>",

--- a/src/transaction/Transaction.js
+++ b/src/transaction/Transaction.js
@@ -883,20 +883,13 @@ export default class Transaction extends Executable {
             for (let i = this._transactions.length; i < index; i++) {
                 this._transactions.push(null);
             }
-        } else if (
-            this._transactions.length > index &&
-            this._transactions[index] != null &&
-            /** @type {proto.ITransaction} */ (this._transactions[index])
-                .signedTransactionBytes != null
-        ) {
-            return;
         }
 
-        this._transactions.push({
+        this._transactions[index] = {
             signedTransactionBytes: ProtoSignedTransaction.encode(
                 this._signedTransactions[index]
             ).finish(),
-        });
+        }
     }
 
     /**


### PR DESCRIPTION
**Description**:
Prevent `toBytes()` from corrupting the transaction object. Without this a code flow like this would fail:
1. build transaction
2. serialize transaction for sending through IPC
3. deserialize and sign trasnaction
4. broadcasting fails

<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
