### PR TITLE
chore: bump libs

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,8 +66,8 @@
         "test:integration:browser:safari": "vite -c vite.config.cjs serve --port 9013 test/ & sleep 10; mocha-webdriver-runner --safari http://localhost:9013/integration.html"
     },
     "dependencies": {
-        "@exodus/hashgraph-cryptography": "^1.0.21-exodus.6",
-        "@exodus/hashgraph-proto": "^2.0.1-beta.2.exodus.6",
+        "@exodus/hashgraph-cryptography": "^1.0.21-exodus.9",
+        "@exodus/hashgraph-proto": "^2.0.1-beta.2.exodus.9",
         "@grpc/grpc-js": "^1.3.4",
         "bignumber.js": "^9.0.1",
         "create-hash": "^1.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -304,10 +304,10 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@exodus/hashgraph-cryptography@^1.0.21-exodus.6":
-  version "1.0.21-exodus.6"
-  resolved "https://registry.yarnpkg.com/@exodus/hashgraph-cryptography/-/hashgraph-cryptography-1.0.21-exodus.6.tgz#8f84a0d8b9a14764f7810f25e2e278ad14e7cf6f"
-  integrity sha512-i1hGEEkIIEDBO5yZlbVNXu4C7RxErE6wgBCSyHjKSBJ+MyBgVFhhrz7DJMupyusDRpxCvoSZOMnHRNdIA/6feA==
+"@exodus/hashgraph-cryptography@^1.0.21-exodus.9":
+  version "1.0.21-exodus.9"
+  resolved "https://registry.yarnpkg.com/@exodus/hashgraph-cryptography/-/hashgraph-cryptography-1.0.21-exodus.9.tgz#19b9a8b5491188c1e19c9bed1fd0dc04f0282eb6"
+  integrity sha512-3INgOSoq/oCbQQa/sJqPoJW8aA28eD36AJlJpsuTajHwHkaaodZsLf1r4jPS1Cey9v7+ZfpGkLRHwiC/va+2AA==
   dependencies:
     bignumber.js "^9.0.1"
     browserify-aes "^1.2.0"
@@ -316,10 +316,10 @@
     pbkdf2 "^3.0.17"
     tweetnacl "^1.0.3"
 
-"@exodus/hashgraph-proto@^2.0.1-beta.2.exodus.6":
-  version "2.0.1-beta.2.exodus.6"
-  resolved "https://registry.yarnpkg.com/@exodus/hashgraph-proto/-/hashgraph-proto-2.0.1-beta.2.exodus.6.tgz#3989caa9a5c53cf34c226c51955aead59c792b30"
-  integrity sha512-+LbJwWoi+nAt80zjfoEfXHtz8z07fe3J+BymDMwZOS4VM6UfOpWhHDz2nh36zmkV5s15bEmuaYouS2OCW4hnBA==
+"@exodus/hashgraph-proto@^2.0.1-beta.2.exodus.9":
+  version "2.0.1-beta.2.exodus.9"
+  resolved "https://registry.yarnpkg.com/@exodus/hashgraph-proto/-/hashgraph-proto-2.0.1-beta.2.exodus.9.tgz#6010b5fa97556efe3c8124ffde6c2908e5892dd4"
+  integrity sha512-k8upboujJ45NCfJN8xKO/yddodutZEn+OSCe9Tdy5W0oek9TuIMn1s+gBd4RdAFZRlh8EhszfGcr3YsAcJjPaw==
   dependencies:
     "@exodus/protobufjs" "^6.11.1-minimal-exodus.1"
 
@@ -1364,7 +1364,7 @@
     "@types/node" "*"
 
 "@types/exodus__hashgraph-cryptography@file:./packages/cryptography":
-  version "1.0.21-exodus.6"
+  version "1.0.21-exodus.9"
   dependencies:
     bignumber.js "^9.0.1"
     browserify-aes "^1.2.0"
@@ -1374,7 +1374,7 @@
     tweetnacl "^1.0.3"
 
 "@types/exodus__hashgraph-proto@file:./packages/proto":
-  version "2.0.1-beta.2.exodus.6"
+  version "2.0.1-beta.2.exodus.9"
   dependencies:
     "@exodus/protobufjs" "^6.11.1-minimal-exodus.1"
 


### PR DESCRIPTION
Bump @exodus/hashgraph-cryptography to v1.0.21-exodus.9 and @exodus/hashgraph-proto to v2.0.1-beta.2.exodus.9

