### PR TITLE
refactor: drop named groups, they are not supported in Hermes

### DIFF
--- a/src/ManagedNodeAddress.js
+++ b/src/ManagedNodeAddress.js
@@ -5,7 +5,7 @@
  * @typedef {import("./address_book/NodeAddress.js").default} NodeAddress
  */
 
-const HOST_AND_PORT = /^(?<address>.*)(:(?<port>\d+))?/;
+const HOST_AND_PORT = /^(.*)(:(\d+))?/;
 
 export default class ManagedNodeAddress {
     /**
@@ -16,24 +16,22 @@ export default class ManagedNodeAddress {
      */
     constructor(props = {}) {
         if (props.address != null) {
-            const hostAndPortResult = HOST_AND_PORT.exec(props.address);
+            let hostAndPortResult = HOST_AND_PORT.exec(props.address);
+            hostAndPortResult =
+                hostAndPortResult &&
+                hostAndPortResult.slice(1).filter(val => val);
 
-            if (hostAndPortResult == null || hostAndPortResult.groups == null) {
+            if (hostAndPortResult == null || !hostAndPortResult.length) {
                 throw new Error(`failed to parse address: ${props.address}`);
             }
 
             /** @type {string} */
-            this._address =
-                /** @type {string} */ (hostAndPortResult.groups["address"]);
+            this._address = /** @type {string} */ (hostAndPortResult[0]);
 
             /** @type {number | null} */
             this._port =
-                hostAndPortResult.groups["port"] != null
-                    ? parseInt(
-                          /** @type {string }*/ (hostAndPortResult.groups[
-                              "port"
-                          ])
-                      )
+                hostAndPortResult[2] != null
+                    ? parseInt(/** @type {string }*/ (hostAndPortResult[2]))
                     : null;
         } else if (props.host != null && props.port != null) {
             /** @type {string} */

--- a/src/ManagedNodeAddress.js
+++ b/src/ManagedNodeAddress.js
@@ -23,17 +23,16 @@ export default class ManagedNodeAddress {
             }
 
             /** @type {string} */
-            this._address = /** @type {string} */ (
-                hostAndPortResult.groups["address"]
-            );
+            this._address =
+                /** @type {string} */ (hostAndPortResult.groups["address"]);
 
             /** @type {number | null} */
             this._port =
                 hostAndPortResult.groups["port"] != null
                     ? parseInt(
-                          /** @type {string }*/ (
-                              hostAndPortResult.groups["port"]
-                          )
+                          /** @type {string }*/ (hostAndPortResult.groups[
+                              "port"
+                          ])
                       )
                     : null;
         } else if (props.host != null && props.port != null) {


### PR DESCRIPTION
We need this for RN64, at least until Hermes adds named regex groups support. This is the only named regex group we use in the mobile app