### PR TITLE
fix: web-channel handling grpc and http errors

### DIFF
--- a/src/EntityIdHelper.js
+++ b/src/EntityIdHelper.js
@@ -315,6 +315,10 @@ export function validateChecksum(shard, realm, num, checksum, client) {
  * @returns {string}
  */
 export function toStringWithChecksum(string, client) {
+    if (client == null) {
+        throw new Error("client cannot be null");
+    }
+    
     if (client._network._ledgerId == null) {
         throw new Error(
             "cannot calculate checksum with a client that does not contain a recognzied ledger ID"

--- a/src/Executable.js
+++ b/src/Executable.js
@@ -287,8 +287,10 @@ export default class Executable {
      */
     _shouldRetryExceptionally(error) {
         return (
+            error.status._code === GrpcStatus.Timeout._code ||
             error.status._code === GrpcStatus.Unavailable._code ||
             error.status._code === GrpcStatus.ResourceExhausted._code ||
+            error.status._code === GrpcStatus.GrpcWeb._code ||
             (error.status._code === GrpcStatus.Internal._code &&
                 RST_STREAM.test(error.message))
         );

--- a/src/Executable.js
+++ b/src/Executable.js
@@ -286,14 +286,20 @@ export default class Executable {
      * @returns {boolean}
      */
     _shouldRetryExceptionally(error) {
-        return (
-            error.status._code === GrpcStatus.Timeout._code ||
-            error.status._code === GrpcStatus.Unavailable._code ||
-            error.status._code === GrpcStatus.ResourceExhausted._code ||
-            error.status._code === GrpcStatus.GrpcWeb._code ||
-            (error.status._code === GrpcStatus.Internal._code &&
-                RST_STREAM.test(error.message))
-        );
+        if (error instanceof GrpcServiceError) {
+            return (
+                error.status._code === GrpcStatus.Timeout._code ||
+                error.status._code === GrpcStatus.Unavailable._code ||
+                error.status._code === GrpcStatus.ResourceExhausted._code ||
+                error.status._code === GrpcStatus.GrpcWeb._code ||
+                (error.status._code === GrpcStatus.Internal._code &&
+                    RST_STREAM.test(error.message))
+            );
+        } else {
+            // if we get to the 'else' statement, the 'error' is instanceof 'HttpError'
+            // and in this case, we have to retry always
+            return true;
+        }
     }
 
     /**

--- a/src/channel/WebChannel.js
+++ b/src/channel/WebChannel.js
@@ -47,6 +47,18 @@ export default class WebChannel extends Channel {
                     }
                 );
 
+                // Check headers for gRPC errors
+                const grpcStatus = response.headers.get("grpc-status");
+                const grpcMessage = response.headers.get("grpc-message");
+                if (grpcStatus != null && grpcMessage != null) {
+                    const error = new GrpcServiceError(
+                        GrpcStatus._fromValue(parseInt(grpcStatus)),
+                    );
+                    error.message = grpcMessage;
+                    callback(error, null);
+                }
+ 
+
                 const responseBuffer = await response.arrayBuffer();
                 const unaryResponse = decodeUnaryResponse(responseBuffer);
 

--- a/src/channel/WebChannel.js
+++ b/src/channel/WebChannel.js
@@ -1,3 +1,5 @@
+import GrpcServiceError from "../grpc/GrpcServiceError.js";
+import GrpcStatus from "../grpc/GrpcStatus.js";
 import Channel, { encodeRequest, decodeUnaryResponse } from "./Channel.js";
 
 export default class WebChannel extends Channel {
@@ -30,23 +32,32 @@ export default class WebChannel extends Channel {
      */
     _createUnaryClient(serviceName) {
         return async (method, requestData, callback) => {
-            const response = await fetch(
-                `${this._address}/proto.${serviceName}/${method.name}`,
-                {
-                    method: "POST",
-                    headers: {
-                        "content-type": "application/grpc-web+proto",
-                        "x-user-agent": "hedera-sdk-js/v2",
-                        "x-grpc-web": "1",
-                    },
-                    body: encodeRequest(requestData),
-                }
-            );
+            try {
 
-            const responseBuffer = await response.arrayBuffer();
-            const unaryResponse = decodeUnaryResponse(responseBuffer);
+                const response = await fetch(
+                    `${this._address}/proto.${serviceName}/${method.name}`,
+                    {
+                        method: "POST",
+                        headers: {
+                            "content-type": "application/grpc-web+proto",
+                            "x-user-agent": "hedera-sdk-js/v2",
+                            "x-grpc-web": "1",
+                        },
+                        body: encodeRequest(requestData),
+                    }
+                );
 
-            callback(null, unaryResponse);
+                const responseBuffer = await response.arrayBuffer();
+                const unaryResponse = decodeUnaryResponse(responseBuffer);
+
+                callback(null, unaryResponse);
+            } catch (error) {
+                const err = new GrpcServiceError(
+                    // retry on grpc web errors
+                    GrpcStatus._fromValue(18)
+                );
+                callback(err, null);
+            }
         };
     }
 }

--- a/src/channel/WebChannel.js
+++ b/src/channel/WebChannel.js
@@ -1,5 +1,7 @@
 import GrpcServiceError from "../grpc/GrpcServiceError.js";
 import GrpcStatus from "../grpc/GrpcStatus.js";
+import HttpError from "../http/HttpError.js";
+import HttpStatus from "../http/HttpStatus.js";
 import Channel, { encodeRequest, decodeUnaryResponse } from "./Channel.js";
 
 export default class WebChannel extends Channel {
@@ -46,6 +48,13 @@ export default class WebChannel extends Channel {
                         body: encodeRequest(requestData),
                     }
                 );
+
+                if (!response.ok) {
+                    const error = new HttpError(
+                        HttpStatus._fromValue(response.status)
+                    );
+                    callback(error, null);
+                }
 
                 // Check headers for gRPC errors
                 const grpcStatus = response.headers.get("grpc-status");

--- a/src/grpc/GrpcStatus.js
+++ b/src/grpc/GrpcStatus.js
@@ -52,6 +52,10 @@ export default class GrpcStatus {
                 return GrpcStatus.Unavailable;
             case 15:
                 return GrpcStatus.DataLoss;
+            case 17:
+                return GrpcStatus.Timeout;
+            case 18:
+                return GrpcStatus.GrpcWeb;
             default:
                 throw new Error(
                     "(BUG) non-exhaustive GrpcStatus switch statement"
@@ -98,6 +102,10 @@ export default class GrpcStatus {
                 return "UNAVAILABLE";
             case GrpcStatus.DataLoss:
                 return "DATA_LOSS";
+            case GrpcStatus.Timeout:
+                return "TIMEOUT";
+            case GrpcStatus.GrpcWeb:
+                return "GRPC_WEB";
 
             default:
                 return `UNKNOWN (${this._code})`;
@@ -129,3 +137,6 @@ GrpcStatus.Unimplemented = new GrpcStatus(12);
 GrpcStatus.Internal = new GrpcStatus(13);
 GrpcStatus.Unavailable = new GrpcStatus(14);
 GrpcStatus.DataLoss = new GrpcStatus(15);
+GrpcStatus.Unauthenticated = new GrpcStatus(16);
+GrpcStatus.Timeout = new GrpcStatus(17);
+GrpcStatus.GrpcWeb = new GrpcStatus(18);

--- a/src/http/HttpError.js
+++ b/src/http/HttpError.js
@@ -1,0 +1,24 @@
+import HttpStatus from "./HttpStatus";
+
+/**
+ * Describes how the http request failed.
+ */
+export default class HttpError extends Error {
+    /**
+     * @param {HttpStatus} status
+     */
+    constructor(status) {
+        super(`failed with error code: ${status.toString()}`);
+
+        /**
+         * @readonly
+         */
+        this.status = status;
+
+        this.name = "HttpError";
+
+        if (typeof Error.captureStackTrace !== "undefined") {
+            Error.captureStackTrace(this, HttpError);
+        }
+    }
+}

--- a/src/http/HttpStatus.js
+++ b/src/http/HttpStatus.js
@@ -1,0 +1,36 @@
+export default class HttpStatus {
+    /**
+     * @hideconstructor
+     * @internal
+     * @param {number} code
+     */
+    constructor(code) {
+        /** @readonly */
+        this._code = code;
+
+        Object.freeze(this);
+    }
+
+    /**
+     * @internal
+     * @param {number} code
+     * @returns {HttpStatus}
+     */
+    static _fromValue(code) {
+        return new HttpStatus(code);
+    }
+
+    /**
+     * @returns {string}
+     */
+    toString() {
+        return this._code.toString();
+    }
+
+    /**
+     * @returns {number}
+     */
+    valueOf() {
+        return this._code;
+    }
+}


### PR DESCRIPTION
## Summary
We sometimes catch the error `(BUG) unexpectedly received no response` that mentions an empty response.  It could be the HTTP errors when connecting to some node proxies or GRPC web (or timeout) errors that we are not handling now. We don't catch them now before decoding the response, so we cannot retry it. If we get this `no response` issue in the wallet, the wallet will be stuck there.

This PR improves:
- Add retry logics on new grpc errors and HTTP errors.
- Check `grpc-status` and `grpc-message` response headers before decoding response body.
- Catch http-errors
 