### PR TITLE
fix: add error for callback in native channel

### DIFF
--- a/src/channel/NativeChannel.js
+++ b/src/channel/NativeChannel.js
@@ -1,5 +1,7 @@
 import Channel, { encodeRequest, decodeUnaryResponse } from "./Channel.js";
 import * as base64 from "../encoding/base64.js";
+import HttpError from "../http/HttpError.js";
+import HttpStatus from "../http/HttpStatus.js";
 
 export default class NativeChannel extends Channel {
     /**
@@ -31,68 +33,79 @@ export default class NativeChannel extends Channel {
      */
     _createUnaryClient(serviceName) {
         return async (method, requestData, callback) => {
-            const data = base64.encode(
-                new Uint8Array(encodeRequest(requestData))
-            );
-
-            const response = await fetch(
-                `${this._address}/proto.${serviceName}/${method.name}`,
-                {
-                    method: "POST",
-                    headers: {
-                        "content-type": "application/grpc-web-text",
-                        "x-user-agent": "hedera-sdk-js/v2",
-                        "x-accept-content-transfer-encoding": "base64",
-                        "x-grpc-web": "1",
-                    },
-                    body: data,
+            try {
+                const data = base64.encode(
+                    new Uint8Array(encodeRequest(requestData))
+                );
+    
+                const response = await fetch(
+                    `${this._address}/proto.${serviceName}/${method.name}`,
+                    {
+                        method: "POST",
+                        headers: {
+                            "content-type": "application/grpc-web-text",
+                            "x-user-agent": "hedera-sdk-js/v2",
+                            "x-accept-content-transfer-encoding": "base64",
+                            "x-grpc-web": "1",
+                        },
+                        body: data,
+                    }
+                );
+    
+                if (!response.ok) {
+                    const error = new HttpError(
+                        HttpStatus._fromValue(response.status),
+                    );
+                    callback(error, null);
                 }
-            );
-
-            const blob = await response.blob();
-
-            /** @type {string} */
-            const responseData = await new Promise((resolve, reject) => {
-                const reader = new FileReader();
-                reader.readAsDataURL(blob);
-                reader.onloadend = () => {
-                    resolve(/** @type {string} */ (reader.result));
-                };
-                reader.onerror = reject;
-            });
-
-            let responseBuffer;
-            if (
-                responseData.startsWith("data:application/octet-stream;base64,")
-            ) {
-                responseBuffer = base64.decode(
-                    responseData.split(
-                        "data:application/octet-stream;base64,"
-                    )[1]
-                );
-            } else if (
-                responseData.startsWith(
-                    "data:application/grpc-web+proto;base64,"
-                )
-            ) {
-                responseBuffer = base64.decode(
-                    responseData.split(
+    
+                const blob = await response.blob();
+    
+                /** @type {string} */
+                const responseData = await new Promise((resolve, reject) => {
+                    const reader = new FileReader();
+                    reader.readAsDataURL(blob);
+                    reader.onloadend = () => {
+                        resolve(/** @type {string} */ (reader.result));
+                    };
+                    reader.onerror = reject;
+                });
+    
+                let responseBuffer;
+                if (
+                    responseData.startsWith("data:application/octet-stream;base64,")
+                ) {
+                    responseBuffer = base64.decode(
+                        responseData.split(
+                            "data:application/octet-stream;base64,"
+                        )[1]
+                    );
+                } else if (
+                    responseData.startsWith(
                         "data:application/grpc-web+proto;base64,"
-                    )[1]
+                    )
+                ) {
+                    responseBuffer = base64.decode(
+                        responseData.split(
+                            "data:application/grpc-web+proto;base64,"
+                        )[1]
+                    );
+                } else {
+                    throw new Error(
+                        `Expected response data to be base64 encode with a 'data:application/octet-stream;base64,' or 'data:application/grpc-web+proto;base64,' prefix, but found: ${responseData}`
+                    );
+                }
+    
+                const unaryResponse = decodeUnaryResponse(
+                    responseBuffer.buffer,
+                    responseBuffer.byteOffset,
+                    responseBuffer.byteLength
                 );
-            } else {
-                throw new Error(
-                    `Expected response data to be base64 encode with a 'data:application/octet-stream;base64,' or 'data:application/grpc-web+proto;base64,' prefix, but found: ${responseData}`
-                );
+    
+                callback(null, unaryResponse);
+            } catch (error) {
+                callback(error, null);
             }
-
-            const unaryResponse = decodeUnaryResponse(
-                responseBuffer.buffer,
-                responseBuffer.byteOffset,
-                responseBuffer.byteLength
-            );
-
-            callback(null, unaryResponse);
         };
     }
 }


### PR DESCRIPTION
## Summary
In mobile, we are encountering an issue where the restoring process gets stuck at 99% (caused by the Hedera monitor being stuck). The monitor only starts the first tick, and if an error occurs, it becomes stuck and cannot proceed to the next tick.

We have already added error handling for the web-channel in [PR #405](https://github.com/ExodusMovement/hedera-sdk-js/pull/405). However, in mobile, which uses the native-channel, we are missing the implementation to propagate errors into the callback. This omission prevents the error from being thrown out of the SDK, causing the monitor to wait for a response indefinitely.

This fix ensures proper error handling in the native-channel, allowing the monitor to handle errors gracefully and proceed as expected