### PR TITLE
fix: add missing return after error callback in NativeChannel and WebChannel

### DIFF
--- a/src/channel/NativeChannel.js
+++ b/src/channel/NativeChannel.js
@@ -57,6 +57,7 @@ export default class NativeChannel extends Channel {
                         HttpStatus._fromValue(response.status),
                     );
                     callback(error, null);
+                    return;
                 }
     
                 const blob = await response.blob();

--- a/src/channel/WebChannel.js
+++ b/src/channel/WebChannel.js
@@ -54,6 +54,7 @@ export default class WebChannel extends Channel {
                         HttpStatus._fromValue(response.status)
                     );
                     callback(error, null);
+                    return;
                 }
 
                 // Check headers for gRPC errors
@@ -65,6 +66,7 @@ export default class WebChannel extends Channel {
                     );
                     error.message = grpcMessage;
                     callback(error, null);
+                    return;
                 }
  
 


### PR DESCRIPTION
While working on https://github.com/ExodusMovement/exodus-hydra/pull/15280 for https://github.com/ExodusMovement/exodus-mobile/issues/35499 I noticed a few missing returns, not sure if these could be causing any issues, but added them for sanity.