### PR TITLE
feat: add FeeEstimateQuery for mirror-node-based fee estimation

### DIFF
--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -91,6 +91,15 @@ export default class Client {
 
         /** @type {number} */
         this._maxBackoff = 8000;
+
+        /**
+         * Optional mirror node REST API base URL used by `FeeEstimateQuery`.
+         * The REST API is independent of the gRPC mirror channel, so we keep
+         * it as a separate setting on the client.
+         *
+         * @type {string | null}
+         */
+        this._mirrorRestApiBaseUrl = null;
     }
 
     /**
@@ -108,6 +117,32 @@ export default class Client {
      */
     get networkName() {
         return this._network.networkName;
+    }
+
+    /**
+     * Configure the mirror node REST API base URL used by `FeeEstimateQuery`.
+     * Pass the URL up to (but not including) `/api/v1` — for example,
+     * `https://mainnet-public.mirrornode.hedera.com/api/v1` is a valid value.
+     *
+     * @param {string} baseUrl
+     * @returns {this}
+     */
+    setMirrorRestApiBaseUrl(baseUrl) {
+        if (typeof baseUrl !== "string" || baseUrl.length === 0) {
+            throw new TypeError(
+                "setMirrorRestApiBaseUrl: baseUrl must be a non-empty string"
+            );
+        }
+        // Drop trailing slashes so we can safely concatenate paths later.
+        this._mirrorRestApiBaseUrl = baseUrl.replace(/\/+$/, "");
+        return this;
+    }
+
+    /**
+     * @returns {string | null}
+     */
+    get mirrorRestApiBaseUrl() {
+        return this._mirrorRestApiBaseUrl;
     }
 
     /**

--- a/src/exports.js
+++ b/src/exports.js
@@ -12,6 +12,8 @@ export { default as AccountUpdateTransaction } from "./account/AccountUpdateTran
 export { default as ContractFunctionResult } from "./contract/ContractFunctionResult.js";
 export { default as ContractLogInfo } from "./contract/ContractLogInfo.js";
 export { default as ExchangeRate } from "./ExchangeRate.js";
+export { default as FeeEstimateMode } from "./network/FeeEstimateMode.js";
+export { default as FeeEstimateQuery } from "./network/FeeEstimateQuery.js";
 export { default as FreezeTransaction } from "./system/FreezeTransaction.js";
 export { default as Hbar } from "./Hbar.js";
 export { default as HbarUnit } from "./HbarUnit.js";

--- a/src/network/FeeEstimateMode.js
+++ b/src/network/FeeEstimateMode.js
@@ -1,0 +1,17 @@
+/**
+ * Mirror node fee estimation modes per HIP-1261. The default is `INTRINSIC`,
+ * which estimates fees from the transaction body alone. `STATE` additionally
+ * factors in current network state (used for queries that depend on storage
+ * costs).
+ *
+ * Values are mapped to the mirror node REST `mode` query parameter as
+ * uppercase strings.
+ *
+ * @enum {number}
+ */
+const FeeEstimateMode = Object.freeze({
+    INTRINSIC: 0,
+    STATE: 1,
+});
+
+export default FeeEstimateMode;

--- a/src/network/FeeEstimateQuery.js
+++ b/src/network/FeeEstimateQuery.js
@@ -1,0 +1,462 @@
+import { Transaction as ProtoTransaction } from "@exodus/hashgraph-proto";
+
+import FeeEstimateMode from "./FeeEstimateMode.js";
+
+/**
+ * @typedef {import("../client/Client.js").default<*, *>} Client
+ * @typedef {import("../transaction/Transaction.js").default} Transaction
+ */
+
+/**
+ * @typedef {object} FetchResponse
+ * @property {boolean} ok
+ * @property {number} status
+ * @property {() => Promise<unknown>} json
+ * @property {() => Promise<string>} [text]
+ */
+
+/**
+ * @typedef {(input: string, init?: object) => Promise<FetchResponse>} FetchImpl
+ */
+
+/**
+ * @returns {FetchImpl | null}
+ */
+function defaultFetch() {
+    // eslint-disable-next-line no-undef, node/no-unsupported-features/es-builtins
+    const g = typeof globalThis !== "undefined" ? globalThis : null;
+    if (g != null && typeof g.fetch === "function") {
+        return /** @type {FetchImpl} */ (g.fetch.bind(g));
+    }
+    return null;
+}
+
+/**
+ * Maximum value (basis points) for the high-volume throttle utilization.
+ * 10000 = 100%. Mirrors upstream HIP-1261.
+ */
+const HIGH_VOLUME_THROTTLE_MAX_BPS = 10000;
+
+const MAX_ATTEMPTS = 5;
+const INITIAL_BACKOFF_MS = 250;
+const MAX_BACKOFF_MS = 8000;
+const REQUEST_TIMEOUT_MS = 15000;
+
+const FEES_PATH = "/network/fees";
+
+/**
+ * Query the mirror node REST API for an estimated fee for a transaction
+ * before submitting it to consensus nodes.
+ *
+ * Backports the public surface of upstream `hiero-ledger/hiero-sdk-js`'s
+ * `FeeEstimateQuery` (HIP-1261 / PR #3478) to this fork. Only the
+ * single-chunk transaction case is supported here; multi-chunk transactions
+ * fail fast so callers can fall back to static fees instead of receiving an
+ * under-estimated first-chunk-only value.
+ *
+ * Usage:
+ *
+ * ```js
+ * const fee = await new FeeEstimateQuery()
+ *     .setTransaction(tx)
+ *     .execute(client);
+ * // fee is a number of tinybars; callers can wrap with Hbar.fromTinybars().
+ * ```
+ *
+ * The mirror REST URL must be configured on the client via
+ * `client.setMirrorRestApiBaseUrl(...)`. If unconfigured, the request fails
+ * fast so callers can fall back to a static fee schedule.
+ */
+export default class FeeEstimateQuery {
+    /**
+     * @param {object} [props]
+     * @param {Transaction} [props.transaction]
+     * @param {number} [props.mode]
+     * @param {number} [props.highVolumeThrottle]
+ * @param {FetchImpl} [props.fetch]
+     *   Optional `fetch` impl. Defaults to `globalThis.fetch`. Tests can
+     *   inject a stub here to avoid touching the network.
+ * @param {number} [props.requestTimeoutMs] Optional per-attempt timeout
+ *   override. Intended for tests.
+     */
+    constructor(props = {}) {
+        /** @type {?Transaction} */
+        this._transaction = null;
+        /** @type {number} */
+        this._mode = FeeEstimateMode.INTRINSIC;
+        /** @type {number} */
+        this._highVolumeThrottle = 0;
+        /** @type {FetchImpl | null} */
+        this._fetch =
+            typeof props.fetch === "function"
+                ? /** @type {FetchImpl} */ (props.fetch)
+                : defaultFetch();
+        /** @type {number} */
+        this._requestTimeoutMs =
+            typeof props.requestTimeoutMs === "number"
+                ? props.requestTimeoutMs
+                : REQUEST_TIMEOUT_MS;
+
+        if (props.transaction != null) {
+            this.setTransaction(props.transaction);
+        }
+        if (props.mode != null) {
+            this.setMode(props.mode);
+        }
+        if (props.highVolumeThrottle != null) {
+            this.setHighVolumeThrottle(props.highVolumeThrottle);
+        }
+    }
+
+    /**
+     * @returns {?Transaction}
+     */
+    get transaction() {
+        return this._transaction;
+    }
+
+    /**
+     * @param {Transaction} transaction
+     * @returns {this}
+     */
+    setTransaction(transaction) {
+        if (transaction == null) {
+            throw new TypeError(
+                "FeeEstimateQuery.setTransaction: transaction is required"
+            );
+        }
+        this._transaction = transaction;
+        return this;
+    }
+
+    /**
+     * @returns {number}
+     */
+    get mode() {
+        return this._mode;
+    }
+
+    /**
+     * @param {number} mode
+     * @returns {this}
+     */
+    setMode(mode) {
+        const value = Number(mode);
+        const validValues = Object.values(FeeEstimateMode).map(Number);
+        if (!validValues.includes(value)) {
+            throw new RangeError(
+                `FeeEstimateQuery.setMode: invalid mode ${String(mode)}. ` +
+                    `Must be one of FeeEstimateMode.INTRINSIC or FeeEstimateMode.STATE.`
+            );
+        }
+        this._mode = value;
+        return this;
+    }
+
+    /**
+     * @returns {number}
+     */
+    get highVolumeThrottle() {
+        return this._highVolumeThrottle;
+    }
+
+    /**
+     * @param {number} throttle Basis points (0–10000).
+     * @returns {this}
+     */
+    setHighVolumeThrottle(throttle) {
+        const value = Number(throttle);
+        if (
+            !Number.isInteger(value) ||
+            value < 0 ||
+            value > HIGH_VOLUME_THROTTLE_MAX_BPS
+        ) {
+            throw new RangeError(
+                `FeeEstimateQuery.setHighVolumeThrottle: ${String(throttle)} ` +
+                    `must be an integer in [0, ${HIGH_VOLUME_THROTTLE_MAX_BPS}].`
+            );
+        }
+        this._highVolumeThrottle = value;
+        return this;
+    }
+
+    /**
+     * @param {Client} client
+     * @returns {Promise<number>} Total estimated fee in tinybars.
+     */
+    async execute(client) {
+        if (this._fetch == null) {
+            throw new Error(
+                "FeeEstimateQuery: a fetch implementation is required " +
+                    "(globalThis.fetch is not available in this environment)"
+            );
+        }
+        if (this._transaction == null) {
+            throw new Error(
+                "FeeEstimateQuery: setTransaction() must be called before execute()"
+            );
+        }
+        if (
+            client == null ||
+            typeof client.mirrorRestApiBaseUrl !== "string" ||
+            client.mirrorRestApiBaseUrl.length === 0
+        ) {
+            throw new Error(
+                "FeeEstimateQuery: client.setMirrorRestApiBaseUrl(...) " +
+                    "must be configured on the client"
+            );
+        }
+
+        const tx = this._transaction;
+        if (typeof tx.isFrozen === "function" && !tx.isFrozen()) {
+            // HIP-1261: auto-freeze if not already frozen.
+            tx.freezeWith(client);
+        }
+        const txWithChunks = /** @type {{ getRequiredChunks?: () => number }} */ (
+            tx
+        );
+        const getRequiredChunks = txWithChunks.getRequiredChunks;
+        if (typeof getRequiredChunks === "function" && getRequiredChunks() > 1) {
+            throw new Error(
+                "FeeEstimateQuery: multi-chunk transactions are not supported"
+            );
+        }
+        await tx._buildAllTransactionsAsync();
+
+        const built = tx._transactions[0];
+        if (built == null) {
+            throw new Error(
+                "FeeEstimateQuery: transaction has no built representation"
+            );
+        }
+
+        const buffer = ProtoTransaction.encode(built).finish();
+        const url = this._buildUrl(client);
+
+        const data = await this._postWithRetry(url, buffer);
+        return parseTotalTinybars(data);
+    }
+
+    /**
+     * @private
+     * @param {Client} client
+     * @returns {string}
+     */
+    _buildUrl(client) {
+        const baseUrl = String(client.mirrorRestApiBaseUrl);
+        const modeParam =
+            this._mode === FeeEstimateMode.STATE ? "STATE" : "INTRINSIC";
+        let query = `mode=${modeParam}`;
+        if (this._highVolumeThrottle > 0) {
+            query += `&high_volume_throttle=${this._highVolumeThrottle}`;
+        }
+        return `${baseUrl}${FEES_PATH}?${query}`;
+    }
+
+    /**
+     * @private
+     * @param {string} url
+     * @param {Uint8Array} body
+     * @returns {Promise<unknown>}
+     */
+    async _postWithRetry(url, body) {
+        const fetchImpl = /** @type {FetchImpl} */ (this._fetch);
+        /** @type {Error | null} */
+        let lastError = null;
+        let backoff = INITIAL_BACKOFF_MS;
+
+        for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+            /** @type {FetchResponse} */
+            let response;
+            try {
+                response = await withTimeout(
+                    fetchImpl(url, {
+                        method: "POST",
+                        headers: { "Content-Type": "application/protobuf" },
+                        body,
+                    }),
+                    this._requestTimeoutMs
+                );
+            } catch (err) {
+                lastError =
+                    err instanceof Error ? err : new Error(String(err));
+                if (attempt < MAX_ATTEMPTS && isRetryableNetworkError(err)) {
+                    await sleep(backoff);
+                    backoff = Math.min(backoff * 2, MAX_BACKOFF_MS);
+                    continue;
+                }
+                throw lastError;
+            }
+
+            if (response.ok) {
+                return response.json();
+            }
+
+            const detail = await readErrorDetail(response);
+            const status = response.status;
+
+            if (status === 400) {
+                throw new Error(
+                    `FeeEstimateQuery: HTTP 400${
+                        detail.length > 0 ? `: ${detail}` : ""
+                    }`
+                );
+            }
+            if (status === 500 || status === 503 || status === 504) {
+                lastError = new Error(
+                    `FeeEstimateQuery: HTTP ${status}${
+                        detail.length > 0 ? `: ${detail}` : ""
+                    }`
+                );
+                if (attempt < MAX_ATTEMPTS) {
+                    await sleep(backoff);
+                    backoff = Math.min(backoff * 2, MAX_BACKOFF_MS);
+                    continue;
+                }
+                throw lastError;
+            }
+
+            throw new Error(
+                `FeeEstimateQuery: HTTP ${status}${
+                    detail.length > 0 ? `: ${detail}` : ""
+                }`
+            );
+        }
+
+        throw lastError != null
+            ? lastError
+            : new Error("FeeEstimateQuery: estimation failed");
+    }
+}
+
+/**
+ * @typedef {object} FeeEstimateResponseJSON
+ * @property {number | string} [total]
+ */
+
+/**
+ * @param {unknown} data
+ * @returns {number}
+ */
+function parseTotalTinybars(data) {
+    if (data == null || typeof data !== "object") {
+        throw new Error("FeeEstimateQuery: empty response from mirror node");
+    }
+    const json = /** @type {FeeEstimateResponseJSON} */ (data);
+    const value = json.total;
+    if (typeof value === "number" && Number.isFinite(value)) {
+        return value;
+    }
+    if (typeof value === "string" && value.length > 0) {
+        const parsed = Number(value);
+        if (Number.isFinite(parsed)) {
+            return parsed;
+        }
+    }
+    throw new Error(
+        "FeeEstimateQuery: response is missing a numeric `total` field"
+    );
+}
+
+/**
+ * @param {number} ms
+ * @returns {Promise<void>}
+ */
+function sleep(ms) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * @template T
+ * @param {Promise<T>} promise
+ * @param {number} ms
+ * @returns {Promise<T>}
+ */
+function withTimeout(promise, ms) {
+    /** @type {ReturnType<typeof setTimeout>} */
+    let timeoutId;
+    /** @type {Promise<never>} */
+    const timeout = new Promise((_, reject) => {
+        timeoutId = setTimeout(() => {
+            reject(new Error(`request timed out after ${ms}ms`));
+        }, ms);
+    });
+
+    const raced = /** @type {Promise<T>} */ (Promise.race([promise, timeout]));
+    return raced.finally(() => {
+        clearTimeout(timeoutId);
+    });
+}
+
+/**
+ * @param {*} err
+ * @returns {boolean}
+ */
+function isRetryableNetworkError(err) {
+    if (!(err instanceof Error)) return false;
+    const name = err.name || "";
+    const message = err.message || "";
+    if (name === "AbortError" || name === "TimeoutError") return true;
+    if (/^FeeEstimateQuery: HTTP 5\d\d/.test(message)) return true;
+    return /timeout|timed out|network|fetch failed|ECONN|ENETUNREACH/i.test(
+        message
+    );
+}
+
+/**
+ * @typedef {object} MirrorErrorMessage
+ * @property {string} [message]
+ * @property {string} [detail]
+ */
+
+/**
+ * @typedef {object} MirrorErrorEnvelope
+ * @property {{ messages?: MirrorErrorMessage[] }} [_status]
+ */
+
+/**
+ * Read a short, human-readable error detail from the mirror node response.
+ * Mirror node REST errors are typically JSON of the form
+ * `{"_status":{"messages":[{"message":"...","detail":"..."}]}}`. Plain text
+ * responses are also handled. Returns an empty string if the body is empty
+ * or unreadable.
+ *
+ * @param {FetchResponse} response
+ * @returns {Promise<string>}
+ */
+async function readErrorDetail(response) {
+    try {
+        if (typeof response.text !== "function") return "";
+        const text = await response.text();
+        if (!text) return "";
+        try {
+            const raw = /** @type {unknown} */ (JSON.parse(text));
+            const parsed = /** @type {MirrorErrorEnvelope} */ (raw);
+            const messages =
+                parsed._status != null &&
+                Array.isArray(parsed._status.messages)
+                    ? parsed._status.messages
+                    : null;
+            const first = messages != null ? messages[0] : null;
+            const detail =
+                first != null && typeof first.detail === "string"
+                    ? first.detail
+                    : "";
+            const message =
+                first != null && typeof first.message === "string"
+                    ? first.message
+                    : "";
+            if (detail.length > 0) {
+                return message.length > 0 ? `${message}: ${detail}` : detail;
+            }
+            if (message.length > 0) {
+                return message;
+            }
+        } catch (_) {
+            // not JSON — fall through to the raw text
+        }
+        return text.slice(0, 500);
+    } catch (_) {
+        return "";
+    }
+}

--- a/test/unit/FeeEstimateQuery.js
+++ b/test/unit/FeeEstimateQuery.js
@@ -1,0 +1,247 @@
+import FeeEstimateQuery from "../src/network/FeeEstimateQuery.js";
+import FeeEstimateMode from "../src/network/FeeEstimateMode.js";
+
+describe("FeeEstimateQuery", function () {
+    const buildFakeTransaction = (
+        built = { signedTransactionBytes: new Uint8Array([1, 2, 3]) },
+        chunks = 1
+    ) => {
+        return {
+            isFrozen: () => true,
+            freezeWith: () => {},
+            getRequiredChunks: () => chunks,
+            _buildAllTransactionsAsync: () => Promise.resolve(),
+            _transactions: [built],
+        };
+    };
+
+    const buildFakeClient = (mirrorRestApiBaseUrl = "https://mirror.example/api/v1") => ({
+        mirrorRestApiBaseUrl,
+    });
+
+    const buildFetch = (responses) => {
+        const calls = [];
+        const queue = Array.isArray(responses) ? responses.slice() : [responses];
+        const fetch = (url, init) => {
+            calls.push({ url, init });
+            const next = queue.shift();
+            if (next == null) {
+                return Promise.reject(new Error("no more responses"));
+            }
+            return Promise.resolve(next);
+        };
+        return { fetch, calls };
+    };
+
+    it("requires setTransaction()", async function () {
+        const { fetch } = buildFetch({});
+        const query = new FeeEstimateQuery({ fetch });
+        let caught;
+        try {
+            await query.execute(buildFakeClient());
+        } catch (err) {
+            caught = err;
+        }
+        expect(caught).to.be.instanceOf(Error);
+        expect(caught.message).to.match(/setTransaction/);
+    });
+
+    it("requires the client to have a mirror REST URL configured", async function () {
+        const { fetch } = buildFetch({});
+        const query = new FeeEstimateQuery({
+            fetch,
+            requestTimeoutMs: 5,
+        }).setTransaction(buildFakeTransaction());
+        let caught;
+        try {
+            await query.execute({ mirrorRestApiBaseUrl: null });
+        } catch (err) {
+            caught = err;
+        }
+        expect(caught).to.be.instanceOf(Error);
+        expect(caught.message).to.match(/setMirrorRestApiBaseUrl/);
+    });
+
+    it("POSTs to /network/fees with mode=INTRINSIC by default and returns total tinybars", async function () {
+        const { fetch, calls } = buildFetch({
+            ok: true,
+            status: 200,
+            json: () => Promise.resolve({ total: 4321 }),
+        });
+        const query = new FeeEstimateQuery({
+            fetch,
+            requestTimeoutMs: 5,
+        }).setTransaction(buildFakeTransaction());
+        const total = await query.execute(buildFakeClient());
+
+        expect(total).to.equal(4321);
+        expect(calls).to.have.length(1);
+        expect(calls[0].url).to.equal(
+            "https://mirror.example/api/v1/network/fees?mode=INTRINSIC"
+        );
+        expect(calls[0].init.method).to.equal("POST");
+        expect(calls[0].init.headers["Content-Type"]).to.equal(
+            "application/protobuf"
+        );
+        expect(calls[0].init.body).to.be.instanceOf(Uint8Array);
+    });
+
+    it("supports STATE mode and high_volume_throttle", async function () {
+        const { fetch, calls } = buildFetch({
+            ok: true,
+            status: 200,
+            json: () => Promise.resolve({ total: "999" }),
+        });
+        const query = new FeeEstimateQuery({
+            fetch,
+            mode: FeeEstimateMode.STATE,
+            highVolumeThrottle: 5000,
+        }).setTransaction(buildFakeTransaction());
+
+        const total = await query.execute(buildFakeClient());
+
+        expect(total).to.equal(999);
+        expect(calls[0].url).to.equal(
+            "https://mirror.example/api/v1/network/fees?mode=STATE&high_volume_throttle=5000"
+        );
+    });
+
+    it("rejects an out-of-range highVolumeThrottle", function () {
+        const { fetch } = buildFetch({});
+        const query = new FeeEstimateQuery({ fetch });
+        expect(() => query.setHighVolumeThrottle(-1)).to.throw(/integer in/);
+        expect(() => query.setHighVolumeThrottle(10001)).to.throw(/integer in/);
+        expect(() => query.setHighVolumeThrottle(1.5)).to.throw(/integer in/);
+    });
+
+    it("rejects an unknown mode", function () {
+        const { fetch } = buildFetch({});
+        const query = new FeeEstimateQuery({ fetch });
+        expect(() => query.setMode(42)).to.throw(/invalid mode/);
+    });
+
+    it("does not retry on HTTP 400 (malformed transaction)", async function () {
+        const { fetch, calls } = buildFetch({
+            ok: false,
+            status: 400,
+            text: () =>
+                Promise.resolve(
+                    JSON.stringify({
+                        _status: {
+                            messages: [
+                                {
+                                    message: "Bad Request",
+                                    detail: "Unable to parse transaction",
+                                },
+                            ],
+                        },
+                    })
+                ),
+        });
+        const query = new FeeEstimateQuery({
+            fetch,
+            requestTimeoutMs: 5,
+        }).setTransaction(buildFakeTransaction());
+
+        let caught;
+        try {
+            await query.execute(buildFakeClient());
+        } catch (err) {
+            caught = err;
+        }
+
+        expect(caught).to.be.instanceOf(Error);
+        expect(caught.message).to.match(/HTTP 400/);
+        expect(caught.message).to.match(/Unable to parse transaction/);
+        expect(calls).to.have.length(1);
+    });
+
+    it("retries 503 then succeeds on the second attempt", async function () {
+        const { fetch, calls } = buildFetch([
+            {
+                ok: false,
+                status: 503,
+                text: () => Promise.resolve(""),
+            },
+            {
+                ok: true,
+                status: 200,
+                json: () => Promise.resolve({ total: 100 }),
+            },
+        ]);
+        const query = new FeeEstimateQuery({
+            fetch,
+            requestTimeoutMs: 5,
+        }).setTransaction(buildFakeTransaction());
+
+        const total = await query.execute(buildFakeClient());
+        expect(total).to.equal(100);
+        expect(calls).to.have.length(2);
+    });
+
+    it("rejects multi-chunk transactions instead of under-estimating the first chunk", async function () {
+        const { fetch, calls } = buildFetch({
+            ok: true,
+            status: 200,
+            json: () => Promise.resolve({ total: 100 }),
+        });
+        const query = new FeeEstimateQuery({ fetch }).setTransaction(
+            buildFakeTransaction(undefined, 2)
+        );
+
+        let caught;
+        try {
+            await query.execute(buildFakeClient());
+        } catch (err) {
+            caught = err;
+        }
+
+        expect(caught).to.be.instanceOf(Error);
+        expect(caught.message).to.match(/multi-chunk/);
+        expect(calls).to.have.length(0);
+    });
+
+    it("retries a timed-out request and then succeeds", async function () {
+        const calls = [];
+        const fetch = (url, init) => {
+            calls.push({ url, init });
+            if (calls.length === 1) {
+                return new Promise(() => {});
+            }
+            return Promise.resolve({
+                ok: true,
+                status: 200,
+                json: () => Promise.resolve({ total: 777 }),
+            });
+        };
+        const query = new FeeEstimateQuery({
+            fetch,
+            requestTimeoutMs: 5,
+        }).setTransaction(buildFakeTransaction());
+
+        const total = await query.execute(buildFakeClient());
+
+        expect(total).to.equal(777);
+        expect(calls).to.have.length(2);
+    });
+
+    it("throws when the response is missing total", async function () {
+        const { fetch } = buildFetch({
+            ok: true,
+            status: 200,
+            json: () => Promise.resolve({ nodeFee: { base: 1 } }),
+        });
+        const query = new FeeEstimateQuery({ fetch }).setTransaction(
+            buildFakeTransaction()
+        );
+
+        let caught;
+        try {
+            await query.execute(buildFakeClient());
+        } catch (err) {
+            caught = err;
+        }
+        expect(caught).to.be.instanceOf(Error);
+        expect(caught.message).to.match(/total/);
+    });
+});

--- a/test/unit/NodeClient.js
+++ b/test/unit/NodeClient.js
@@ -1,6 +1,39 @@
 import { Client } from "../src/browser.js";
 
 describe("Client", function () {
+    describe("setMirrorRestApiBaseUrl()", function () {
+        it("stores the URL on the client and trims trailing slashes", function () {
+            const client = Client.forNetwork({
+                "node-a:50211": "0.0.3",
+            });
+            client.setMirrorRestApiBaseUrl(
+                "https://mirror.example/api/v1//"
+            );
+            expect(client.mirrorRestApiBaseUrl).to.equal(
+                "https://mirror.example/api/v1"
+            );
+        });
+
+        it("throws on an empty or non-string URL", function () {
+            const client = Client.forNetwork({
+                "node-a:50211": "0.0.3",
+            });
+            expect(() => client.setMirrorRestApiBaseUrl("")).to.throw(
+                /non-empty string/
+            );
+            expect(() => client.setMirrorRestApiBaseUrl(null)).to.throw(
+                /non-empty string/
+            );
+        });
+
+        it("returns null until configured", function () {
+            const client = Client.forNetwork({
+                "node-a:50211": "0.0.3",
+            });
+            expect(client.mirrorRestApiBaseUrl).to.equal(null);
+        });
+    });
+
     it("should support multiple IPs per node account ID", async function () {
         let nodes = {
             "0.testnet.hedera.com:50211": "0.0.3",


### PR DESCRIPTION
## Problem

Hedera fee estimation in callers (e.g. `@exodus/hedera-api`) currently relies on static tinybar constants. They go stale, do not reflect HBAR/USD movement, and cannot account for per-transaction gas/extras. The existing async fee path in the asset repo wraps a constant lookup, so there is no SDK surface to plug a real estimator into.

Upstream `hiero-ledger/hiero-sdk-js` solves this with `FeeEstimateQuery` (HIP-1261 / PR #3478), which queries the mirror node REST API (`POST /network/fees`) with the encoded transaction and returns a precise estimate. This PR backports the public surface of that feature to our fork — minimal scope, safe to roll back, and designed to slot into the asset repo's existing async-first / sync-fallback fee flow without behavior changes.

## Solution

Add `FeeEstimateQuery`, `FeeEstimateMode`, and `Client.setMirrorRestApiBaseUrl()` to the SDK. Callers that opt in get a precise estimate; on any error the SDK throws so callers can fall back to their existing static fee schedule. No public API changes for existing callers.

This PR backports the fee estimation API from the upstream JS SDK. The upstream implementation was merged in hiero-ledger/hiero-sdk-js via [PR #3478](https://github.com/hiero-ledger/hiero-sdk-js/pull/3478), adding FeeEstimateQuery, FeeEstimateMode, and mirror-node REST fee estimation for HIP-1261. Our PR keeps a smaller scope tailored to this fork, but follows the same upstream API/wire behavior: POST /network/fees, protobuf transaction body, mode=INTRINSIC|STATE, optional high_volume_throttle, and JSON fee response parsing.

**Related upstream issue**: [hiero-ledger/hiero-sdk-js #3399: HIP 1261: Simple Fees](https://github.com/hiero-ledger/hiero-sdk-js/issues/3399)

### New SDK surface

| Symbol | Purpose |
|--------|---------|
| `FeeEstimateQuery` | Single-chunk transaction estimate via `POST {mirrorRestApiBaseUrl}/network/fees` |
| `FeeEstimateMode` | `INTRINSIC` (default, body only) / `STATE` (factors current network state) |
| `Client.setMirrorRestApiBaseUrl(url)` | Configure mirror REST URL (separate from the gRPC mirror network) |
| `Client.mirrorRestApiBaseUrl` | Getter, defaults to `null` |

Asset repo integration (no public API change required):
```js
import { FeeEstimateQuery } from '@exodus/hashgraph-sdk'
client.setMirrorRestApiBaseUrl(mirrorRestUrl)
const tinybars = await new FeeEstimateQuery().setTransaction(tx).execute(client)
```

## Safety guards

- **Multi-chunk transactions throw fast** instead of being silently under-estimated by only the first chunk's fee.
- **Per-attempt 15s fetch timeout** (configurable via `requestTimeoutMs` for tests). Timeout is treated as a retryable transient failure, so callers fall back instead of hanging.
- **HTTP 400** (malformed transaction) is **never retried**.
- **HTTP 500/503/504** and network errors are retried with bounded exponential backoff (250ms → 8000ms, max 5 attempts).
- **Auto-freeze** if the transaction is not already frozen, per HIP-1261.
- **No transaction signing or submission behavior changed.**
- **No new dependencies.**


## Test plan

- [x] 11 new tests for `FeeEstimateQuery` covering: requires transaction, requires mirror URL, default mode, STATE + high-volume throttle, invalid mode/throttle, no retry on 400, retry on 503, multi-chunk rejection, retry on timeout, missing `total` field
- [x] 3 new tests for `Client.setMirrorRestApiBaseUrl()` covering: trims trailing slashes, rejects empty/non-string, defaults to null
- [x] Full unit suite: 65 passing, 1 pre-existing failure (`grpc is not defined` in `AccountInfoMocking`, unrelated)
- [x] Lint clean for new and changed files (modulo a pre-existing fork-wide `jsdoc/check-tag-names` config issue tracked separately)
